### PR TITLE
🚧✨ WIP: add basic pageRank + personalized pageRank

### DIFF
--- a/packages/clubhouse-crawler/src/graphdb/labels.ts
+++ b/packages/clubhouse-crawler/src/graphdb/labels.ts
@@ -1,0 +1,1 @@
+export const USER: string = 'User';

--- a/packages/clubhouse-crawler/src/graphdb/projections.ts
+++ b/packages/clubhouse-crawler/src/graphdb/projections.ts
@@ -1,0 +1,1 @@
+export const USER_FOLLOWERS: string = 'user_followers';

--- a/packages/clubhouse-crawler/src/graphdb/relationships.ts
+++ b/packages/clubhouse-crawler/src/graphdb/relationships.ts
@@ -1,0 +1,1 @@
+export const FOLLOWS: string = 'FOLLOWS';

--- a/packages/clubhouse-crawler/src/neo4j.ts
+++ b/packages/clubhouse-crawler/src/neo4j.ts
@@ -10,7 +10,12 @@ import {
   TopicId
 } from 'clubhouse-client'
 
+
 import { sanitize } from './utils'
+
+import { USER } from './graphdb/labels.js';
+import { FOLLOWS } from './graphdb/relationships.js';
+import { USER_FOLLOWERS } from './graphdb/projections.js';
 
 export type TransactionOrSession = neo4j.Transaction | neo4j.Session
 
@@ -576,5 +581,103 @@ export const getUsersInvitedById = (
       LIMIT ${limit}
     `,
     { userId }
+  )
+}
+
+/**
+ * Creates a projection graph for the (User)-[:FOLLOWING]-(User)
+ * 
+ * to be used for certain algorithms like pageRank
+ */
+export const createUserFollowersGraph = (tx: TransactionOrSession) => {
+  return tx.run(
+    `
+      CALL gds.graph.create(
+        '${USER_FOLLOWERS}',
+        '${USER}',
+        '${FOLLOWS}'
+      )
+    `,
+  )
+}
+
+/**
+ * Runs a page rank algorithm on the projection USER_FOLLOWERS and WRITES the result to the user node
+ */
+export const runPageRankWrite = (tx: TransactionOrSession, {
+  maxIterations = 100,
+  dampingFactor = 0.85,
+  writeProperty = 'pagerank',
+  relationshipWeightProperty,
+  tolerance,
+}: {
+  maxIterations: number,
+  dampingFactor: number,
+  writeProperty: string,
+  relationshipWeightProperty?: string,
+  tolerance?: number,
+}) => {
+  return tx.run(
+    `
+      CALL gds.pageRank.write('${USER_FOLLOWERS}', {
+        maxIterations: ${maxIterations},
+        dampingFactor: ${dampingFactor},
+        ${relationshipWeightProperty ? `relationshipWeightProperty: ${relationshipWeightProperty},` : ''}
+        ${tolerance !== undefined ? `tolerance: ${tolerance},` : ''}
+        writeProperty: '${writeProperty}'
+      })
+      YIELD nodePropertiesWritten, ranIterations
+    `, {
+      maxIterations,
+      dampingFactor,
+      writeProperty,
+      relationshipWeightProperty,
+      tolerance,
+    },
+  )
+}
+
+/**
+ * Runs a personalized page rank algorithm on the projection USER_FOLLOWERS and streams the result
+ */
+export const runPersonalizedPageRank = (tx: TransactionOrSession, user_id: string, {
+  maxIterations = 100,
+  dampingFactor = 0.85,
+  relationshipWeightProperty,
+  tolerance,
+}: {
+  maxIterations: number,
+  dampingFactor: number,
+  relationshipWeightProperty?: string,
+  tolerance?: number,
+}, {
+  limit = 1000,
+  skip = 0
+}: {
+  limit?: number
+  skip?: number
+}) => {
+  return tx.run(
+    `
+      MATCH (user:${USER} {user_id: $user_id)
+      CALL gds.pageRank.stream('${USER_FOLLOWERS}', {
+        maxIterations: $maxIterations,
+        dampingFactor: $dampingFactor,
+        ${relationshipWeightProperty ? 'relationshipWeightProperty: $relationshipWeightProperty,' : ''}
+        ${tolerance !== undefined ? 'tolerance: $tolerance,' : ''}
+        sourceNodes: [user]
+      })
+      YIELD nodeId, score
+      RETURN gds.util.asNode(nodeId).name AS name, score
+      ORDER BY score DESC, name ASC
+      SKIP ${skip}
+      LIMIT ${limit}
+    `, {
+      user_id,
+      maxIterations,
+      dampingFactor,
+      relationshipWeightProperty,
+      tolerance,
+    },
   )
 }

--- a/packages/clubhouse-crawler/src/types.ts
+++ b/packages/clubhouse-crawler/src/types.ts
@@ -15,5 +15,8 @@ export interface UserNode extends neo4j.Node {
     time_created: neo4j.DateTime
     time_scraped: neo4j.DateTime
     is_blocked_by_network: string
+    // CHS
+    /** Global PageRank score - written async by runPageRankWrite */
+    pagerank: number,
   }
 }


### PR DESCRIPTION
## Description
Add PageRank feature

### Neo4j:
– Add `createUserFollowersGraph` to create a native inMemory projection for the user and following nodes and relationships
– Add `runPageRankWrite` which runs a pageRank algorithm on the projected graph mentioned above, and writes the pagerank score to the user node
– Add `runPersonalizedPageRank` which runs a personalized pageRank algorithm biased towards a certain user, this results in a subgraph of user nodes which are streamed back to the output

### Structure:
– Add a subfolder `graphdb` (name to be changed) where we have 3 files including the nodes, relationships and projections we use in centralized files.

### Next steps:
- [ ] Awaiting Travis updating the neo4j instance configuration to allow for graph algorithms
- [ ] Running the cypher queries on the client and discuss the results
- [ ] Decide on client side tasks if need be